### PR TITLE
Tab Names + URL Changes

### DIFF
--- a/src/components/CourseCard.js
+++ b/src/components/CourseCard.js
@@ -18,7 +18,7 @@ const BrowseCourseCard = ({ course, progress }) => {
 
   return (
     <Box sx={{ padding: '10px 0' }}>
-      <ButtonBase href={'/course/' + course.uid}>
+      <ButtonBase href={'/tutorial/' + course.uid}>
         <Grid container rowSpacing={1} columnSpacing={{ xs: 2, sm: 2, md: 3 }}>
           <Grid item xs={6}>
             <Box

--- a/src/components/CoursePage/CourseInfo.js
+++ b/src/components/CoursePage/CourseInfo.js
@@ -30,6 +30,7 @@ import { useTranslation } from 'react-i18next'
 import { categories } from '../../assets/options/categories'
 import { handleAddToDownloads } from './handleAddToDownloads'
 
+
 function CourseInfo({
   course,
   setOpenSnackbar,

--- a/src/components/CoursePage/CourseSection.js
+++ b/src/components/CoursePage/CourseSection.js
@@ -30,6 +30,8 @@ import CheckSimpleIcon from '@mui/icons-material/Check'
 import { useTranslation } from 'react-i18next'
 import CourseCreatingButtons from './CourseCreatingButtons'
 import { PageHeading } from 'components/PageHeading'
+import { Helmet } from 'react-helmet'
+
 
 function TabPanel(props) {
   const { children, value, index, ...other } = props
@@ -113,6 +115,9 @@ function CourseSection({ data, courseData, courseProgress }) {
           'linear-gradient(180deg, rgba(11, 9, 25, 0) 0%, rgba(11, 9, 25, 0.11) 200px, rgba(11, 9, 25, 0.64) 400px, #0B0919 600px)',
       }}
     >
+    <Helmet>
+      <title>{courseData?.seriesName} | Create to Learn</title>
+    </Helmet>
       <Container
         sx={{
           padding: '0',

--- a/src/components/CreatorSection.js
+++ b/src/components/CreatorSection.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react'
+import { Helmet } from 'react-helmet'
 import Container from '@mui/material/Container'
 import Box from '@mui/material/Box'
 import Typography from '@mui/material/Typography'
@@ -17,6 +18,9 @@ function CreatorSection({ coursesByCreator, creator }) {
 
   return (
     <Section>
+    <Helmet>
+      <title>{creator.name} | Creators | Create to Learn</title>
+    </Helmet>
       <Container>
         <Box sx={{display: {md: 'flex'}, gap: {md: '20px'}, paddingBottom: {md: '40px'}}}>
           <Box

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -92,7 +92,7 @@ function App(props) {
 
                     <Route
                       exact
-                      path="/course/:courseId"
+                      path="/tutorial/:courseId"
                       component={CoursePage}
                     />
 

--- a/src/pages/browse.js
+++ b/src/pages/browse.js
@@ -5,7 +5,7 @@ import BrowseSection from './../components/Browse/BrowseSection'
 function BrowsePage(props) {
   return (
     <>
-      <Meta title="Browse" />
+      <Meta title="Browse | Create to Learn" />
       <BrowseSection />
     </>
   )

--- a/src/pages/contact.js
+++ b/src/pages/contact.js
@@ -5,7 +5,7 @@ import ContactSection from '../components/Unused/ContactSection'
 function ContactPage(props) {
   return (
     <>
-      <Meta title="Contact" />
+      <Meta title="Contact | Create to Learn" />
       <ContactSection
         bgColor="default"
         size="medium"

--- a/src/pages/course.js
+++ b/src/pages/course.js
@@ -21,7 +21,7 @@ function CoursePage(props) {
 
   return (
     <>
-      <Meta title="Course" />
+      <Meta title="Course | Create to Learn" />
       {data && (
         <CourseSection
           bgColor="default"

--- a/src/pages/dashboard.js
+++ b/src/pages/dashboard.js
@@ -5,7 +5,7 @@ import DashboardSection from './../components/Dashboard/DashboardSection'
 function DashboardPage(props) {
   return (
     <>
-      <Meta title="Dashboard" />
+      <Meta title="Dashboard | Create to Learn" />
       <DashboardSection
         bgColor="default"
         size="medium"

--- a/src/pages/faq.js
+++ b/src/pages/faq.js
@@ -5,7 +5,7 @@ import FaqSection from '../components/Unused/FaqSection'
 function FaqPage(props) {
   return (
     <>
-      <Meta title="Faq" />
+      <Meta title="FAQ - Create to Learn" />
       <FaqSection
         bgColor="default"
         size="medium"

--- a/src/pages/legal.js
+++ b/src/pages/legal.js
@@ -8,7 +8,7 @@ function LegalPage(props) {
 
   return (
     <>
-      <Meta title="Legal" />
+      <Meta title="Legal | Create to Learn" />
       <LegalSection
         bgColor="default"
         size="normal"

--- a/src/pages/myCourses.js
+++ b/src/pages/myCourses.js
@@ -5,7 +5,7 @@ import MyCoursesSection from '../components/MyCourses/MyCoursesSection'
 function MyCoursesPage(props) {
   return (
     <>
-      <Meta title="My Courses" />
+      <Meta title="My Courses | Create to Learn" />
       <MyCoursesSection />
     </>
   )

--- a/src/pages/pricing.js
+++ b/src/pages/pricing.js
@@ -5,7 +5,7 @@ import PricingSection from '../components/Unused/PricingSection'
 function PricingPage(props) {
   return (
     <>
-      <Meta title="Pricing" />
+      <Meta title="Pricing | Create to Learn" />
       <PricingSection
         bgColor="default"
         size="medium"

--- a/src/pages/settings.js
+++ b/src/pages/settings.js
@@ -8,7 +8,7 @@ function SettingsPage(props) {
 
   return (
     <>
-      <Meta title="Settings" />
+      <Meta title="Settings | Create to Learn" />
       <SettingsSection
         bgColor="default"
         bgImage=""

--- a/src/pages/signUp.js
+++ b/src/pages/signUp.js
@@ -5,7 +5,7 @@ import SignUpSection from 'components/SignUp/SignUpSection'
 function SignUpPage() {
   return (
     <>
-      <Meta title="Sign Up" />
+      <Meta title="Sign Up | Create to Learn" />
       <SignUpSection />
     </>
   )

--- a/src/pages/verified.js
+++ b/src/pages/verified.js
@@ -14,7 +14,7 @@ function VerifiedPage(props) {
   }, [])
   auth.parseHash(window.location.hash)
   return <>
-    <Meta title="Verified Page" />
+    <Meta title="Verified Page | Create to Learn" />
     <Section>
       <Container>
         <h1>Your account has been verified! You can close this tab</h1>


### PR DESCRIPTION
# Description
[ClickUp Ticket - Title Structure](https://app.clickup.com/t/9009201449/TIG-542)

- Changed tab names to their proper titles --> [Title] | Create to Learn
- Updated favicon
- URL changes from '/course' to '/tutorial'

**Not 100% sure about the last two sections of the tickets, didn't know what 'open graph data' is**

## After
![image](https://github.com/TakingITGlobal/create-to-learn/assets/132935720/a80a2c6e-26da-40e6-b753-55c12e4d551c)
![image](https://github.com/TakingITGlobal/create-to-learn/assets/132935720/ca70fc68-f19a-45aa-a470-455ade7b1be5)
