### PR TITLE
Tig 203 bug with onboarding stepper

### DIFF
--- a/src/assets/locales/en/translation.json
+++ b/src/assets/locales/en/translation.json
@@ -57,7 +57,7 @@
       "skip-btn": "I'm not attending school"
     },
     "interests": {
-      "subheader": "Pick three topics you're interested in",
+      "subheader": "Pick up to three topics you're interested in",
       "header": "I am interested in..",
       "header2": "",
       "skip-btn": "Prefer not to say"
@@ -65,6 +65,12 @@
     "email": {
       "subheader": "Tell us more about you, so we can personalize your experience",
       "header": "I want to be a.",
+      "header2": "",
+      "skip-btn": "Prefer not to say"
+    },
+    "displayName": {
+      "subheader": "This is your name on the app",
+      "header": "I want to be called ...",
       "header2": "",
       "skip-btn": "Prefer not to say"
     }

--- a/src/assets/locales/en/translation.json
+++ b/src/assets/locales/en/translation.json
@@ -54,23 +54,17 @@
       "subheader": "Scroll or search to find your school",
       "header": "I'm attending",
       "header2": "",
-      "skip-btn": "Prefer not to say"
+      "skip-btn": "I'm not attending school"
     },
     "interests": {
-      "subheader": "Tell us more about you, so we can personalize your experience",
-      "header": "I am..",
+      "subheader": "Pick three topics you're interested in",
+      "header": "I am interested in..",
       "header2": "",
       "skip-btn": "Prefer not to say"
     },
     "email": {
       "subheader": "Tell us more about you, so we can personalize your experience",
-      "header": "I am..",
-      "header2": "",
-      "skip-btn": "Prefer not to say"
-    },
-    "displayName": {
-      "subheader": "Tell us more about you, so we can personalize your experience",
-      "header": "I am..",
+      "header": "I want to be a.",
       "header2": "",
       "skip-btn": "Prefer not to say"
     }

--- a/src/components/OnboardingView.js
+++ b/src/components/OnboardingView.js
@@ -31,56 +31,36 @@ const styles = (theme) => ({
   },
   scrollBox: {
     overflowY: 'scroll',
-    height: '40vh',
+    height: '50vh',
     textAlign: 'left',
     gap: 8,
   },
 })
 
-function InputView(props) {
+function TitleSection({ value }) {
   const { t } = useTranslation()
-  const swiper = useSwiper()
-  const [cur, setCur] = useState(0)
-
-  const { data, value, formProgress, setFormProgress } = props
-  const required = props.required ? props.required : false
-
-  useEffect(() => {
-    swiper.on('slideChange', (swipe) => {
-      setCur(swipe.activeIndex)
-    })
-  }, [swiper])
-
-  function handleFormProgress() {
-    if (formProgress <= cur) setFormProgress((formProgress) => formProgress + 1)
-  }
-  const setLocal = (id, val) => {
-    localStorage.setItem(id, val)
-    handleFormProgress()
-    swiper.slideNext()
-  }
 
   return (
     <Box
       sx={{
-        padding: '50px 1em 1em 1em',
+        padding: '50px 1em 1.5em 1.5em',
         maxWidth: { md: '850px' },
         margin: { md: '0 auto' },
       }}
     >
-      <Stack direction="column" sx={{ pb: '40px' }}>
+      <Stack direction="column">
         <Typography variant="decorative">
-          {t(`onboarding.${props.value}.header`)}
+          {t(`onboarding.${value}.header`)}
         </Typography>
         <Typography variant="secondary" sx={{ color: '#D2CCFB' }}>
-          {t(`onboarding.${props.value}.header2`)}
+          {t(`onboarding.${value}.header2`)}
         </Typography>
         <Typography variant="secondary">
-          {t(`onboarding.${props.value}.subheader`)}
+          {t(`onboarding.${value}.subheader`)}
         </Typography>
       </Stack>
 
-      <Grid
+      {/* <Grid
         sx={{ maxHeight: '350px', overflow: 'scroll', padding: '20px 0' }}
         container
       >
@@ -108,7 +88,7 @@ function InputView(props) {
         ) : (
           <Box style={{ height: 36.5 }} />
         )}
-      </Stack>
+      </Stack> */}
     </Box>
   )
 }
@@ -192,6 +172,7 @@ export function WindowView(props) {
 export function InputSelectView(props) {
   const { multi, value, options } = props
   const classes = useClasses(styles)
+
   const cols = props.cols ? props.cols : 1
 
   const [data, setData] = useState(multi ? [] : '')
@@ -204,89 +185,86 @@ export function InputSelectView(props) {
       : setData(e.target.value)
   }
 
-  return (
-    <InputView data={data} {...props}>
-      {multi ? (
-        <Grid
-          container
-          sx={{
-            gap: '10px',
-            justifyContent: 'space-between',
-            marginBottom: '2em',
-          }}
-        >
-          {options?.map((val, i) => (
-            <Box
-              as="div"
-              key={i}
-              className={classes.btnInput}
-              sx={{
-                flex: `0 1 calc(calc(100% / ${cols}) - (10px * ${cols - 1}))`,
-              }}
+  return multi ? (
+    <Box>
+      <TitleSection value={value} />
+      <Grid
+        container
+        sx={{
+          gap: '10px',
+          padding: '1em',
+        }}
+      >
+        {options?.map((val, i) => (
+          <Box
+            as="div"
+            key={i}
+            className={classes.btnInput}
+            sx={{
+              flex: `0 1 calc(calc(100% / ${cols}) - (10px * ${cols - 1}))`,
+            }}
+          >
+            <input
+              onChange={onChange}
+              type="checkbox"
+              value={val}
+              name={value}
+              id={val}
+              hidden
+            />
+            <Button
+              variant="selection"
+              component="label"
+              fullWidth
+              htmlFor={val}
+              className={data.includes(val) ? 'active' : ''}
             >
-              <input
-                onChange={onChange}
-                type="checkbox"
-                value={val}
-                name={value}
-                id={val}
-                hidden
-              />
-              <Button
-                variant="selection"
-                component="label"
-                fullWidth
-                htmlFor={val}
-                className={data.includes(val) ? 'active' : ''}
-              >
-                {val}
-                <Check />
-              </Button>
-            </Box>
-          ))}
-        </Grid>
-      ) : (
-        <Grid
-          container
-          style={{ gap: '10px', justifyContent: 'space-between' }}
-        >
-          {options?.map((val, i) => (
-            <Box
-              as="div"
-              key={i}
-              className={classes.btnInput}
-              sx={{
-                flex: `0 1 calc(calc(100% / ${cols}) - (10px * ${cols - 1}))`,
-              }}
+              {val}
+              <Check />
+            </Button>
+          </Box>
+        ))}
+      </Grid>
+    </Box>
+  ) : (
+    <Box>
+      <Grid container style={{ gap: '10px', justifyContent: 'space-between' }}>
+        {options?.map((val, i) => (
+          <Box
+            as="div"
+            key={i}
+            className={classes.btnInput}
+            sx={{
+              flex: `0 1 calc(calc(100% / ${cols}) - (10px * ${cols - 1}))`,
+            }}
+          >
+            <input
+              onChange={onChange}
+              type="radio"
+              value={val}
+              name={value}
+              id={val}
+              hidden
+            />
+            <Button
+              variant="selection"
+              component="label"
+              fullWidth
+              htmlFor={val}
+              size="small"
             >
-              <input
-                onChange={onChange}
-                type="radio"
-                value={val}
-                name={value}
-                id={val}
-                hidden
-              />
-              <Button
-                variant="selection"
-                component="label"
-                fullWidth
-                htmlFor={val}
-                size="small"
-              >
-                {val}
-                <Check />
-              </Button>
-            </Box>
-          ))}
-        </Grid>
-      )}
-    </InputView>
+              {val}
+              <Check />
+            </Button>
+          </Box>
+        ))}
+      </Grid>
+    </Box>
   )
 }
 
 export function InputPillView(props) {
-  const { value, options } = props
+  const { options, value } = props
 
   const [data, setData] = useState([])
 
@@ -297,13 +275,15 @@ export function InputPillView(props) {
   }
 
   return (
-    <InputView data={data} {...props}>
+    <Box>
+      <TitleSection value={value} />
       <Grid
         container
         sx={{
           gap: '10px',
           justifyContent: 'space-between',
-          marginBottom: '2em',
+          marginTop: '2em',
+          padding: '1.5em',
         }}
       >
         {options?.map((val, i) => (
@@ -324,7 +304,7 @@ export function InputPillView(props) {
           </Box>
         ))}
       </Grid>
-    </InputView>
+    </Box>
   )
 }
 
@@ -336,16 +316,17 @@ export function InputTextView(props) {
   }
 
   return (
-    <InputView data={data} {...props}>
+    <>
+      <TitleSection value={props.value} />
       <Grid container item className={classes.gridColumn} onChange={onChange}>
         <TextField variant="outlined" fullWidth />
       </Grid>
-    </InputView>
+    </>
   )
 }
 
 export function InputSearchView(props) {
-  const { value, formProgress, options } = props
+  const { value, options } = props
 
   const classes = useClasses(styles)
   const { t } = useTranslation()
@@ -385,50 +366,54 @@ export function InputSearchView(props) {
     </div>
   )
   return (
-    <InputView data={data} {...props}>
-      <Stack direction="column" sx={{ padding: '10px 0' }}>
-        {data.length > 0 && (
-          <Button variant="contained" size="small">
-            {data}
-          </Button>
-        )}
-      </Stack>
+    <>
+      <TitleSection value={value} />
 
-      <TextField variant="outlined" onChange={onInputChange} fullWidth />
-
-      <Grid container item className={classes.gridColumn}>
-        <Grid className={classes.scrollBox}>
-          <Box sx={{ padding: '10px 0' }}>
-            <input
-              type="radio"
-              value="other"
-              id="other"
-              name={value}
-              hidden
-              onChange={onChange}
-            />
-            <Button
-              variant="selection"
-              component="label"
-              htmlFor="other"
-              size="small"
-              fullWidth
-            >
-              {t('btn.missing', { value: value })}
+      <Box sx={{ margin: '1.5em' }}>
+        <Stack direction="column">
+          {data.length > 0 && (
+            <Button variant="contained" size="small">
+              {data}
             </Button>
-          </Box>
-          <List
-            itemData={filtered}
-            itemCount={filtered.length}
-            height={420}
-            itemSize={65}
-            width="100%"
-          >
-            {Row}
-          </List>
+          )}
+        </Stack>
+
+        <TextField variant="outlined" onChange={onInputChange} fullWidth />
+
+        <Grid className={classes.gridColumn}>
+          <Grid className={classes.scrollBox}>
+            <Box sx={{ padding: '10px 0' }}>
+              <input
+                type="radio"
+                value="other"
+                id="other"
+                name={value}
+                hidden
+                onChange={onChange}
+              />
+              <Button
+                variant="selection"
+                component="label"
+                htmlFor="other"
+                size="small"
+                fullWidth
+              >
+                {t('btn.missing', { value: value })}
+              </Button>
+            </Box>
+            <List
+              itemData={filtered}
+              itemCount={filtered.length}
+              height={420}
+              itemSize={65}
+              width="100%"
+            >
+              {Row}
+            </List>
+          </Grid>
         </Grid>
-      </Grid>
-    </InputView>
+      </Box>
+    </>
   )
 }
 

--- a/src/components/OnboardingView.js
+++ b/src/components/OnboardingView.js
@@ -378,10 +378,17 @@ export function EmailView() {
   const handleFormAlert = (data) => {
     setFormAlert(data)
   }
-  const handleAuth = (email) => {
-    localStorage.setItem('email', email)
-    swiper.slideNext()
+  
+  const handleAuth = (userData) => {
+    const email = userData.email
+    if (email) {
+      localStorage.setItem('email', email);
+      swiper.slideNext();
+    } else {
+      console.error("Email is missing in userData");
+    }
   }
+
   return (
     <Box sx={{ padding: '50px 1em 1em 1em' }}>
       <Grid container item className={classes.gridColumn} md={6}>

--- a/src/components/OnboardingView.js
+++ b/src/components/OnboardingView.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState } from 'react'
 import useClasses from '../hooks/useClasses'
 import {
   Grid,
@@ -31,7 +31,7 @@ const styles = (theme) => ({
   },
   scrollBox: {
     overflowY: 'scroll',
-    height: '50vh',
+    height: '40vh',
     textAlign: 'left',
     gap: 8,
   },
@@ -59,48 +59,15 @@ function TitleSection({ value }) {
           {t(`onboarding.${value}.subheader`)}
         </Typography>
       </Stack>
-
-      {/* <Grid
-        sx={{ maxHeight: '350px', overflow: 'scroll', padding: '20px 0' }}
-        container
-      >
-        {props.children}
-      </Grid>
-      <Stack
-        spacing={2}
-        sx={{ flexDirection: { xs: 'column', md: 'row' }, padding: '20px 0' }}
-      >
-        <Button
-          color="info"
-          sx={{
-            backgroundColor: 'white !important',
-            color: 'black !important',
-          }}
-          onClick={() => setLocal(value, data)}
-          disabled={!data.length > 0}
-        >
-          {t('btn.continue')}
-        </Button>
-        {!required ? (
-          <Button variant="text" onClick={() => setLocal(value, '')}>
-            {t(`onboarding.${value}.skip-btn`)}
-          </Button>
-        ) : (
-          <Box style={{ height: 36.5 }} />
-        )}
-      </Stack> */}
     </Box>
   )
 }
 
-export function WelcomeView(props) {
+export function WelcomeView({ image }) {
   const swiper = useSwiper()
   const { t } = useTranslation()
 
-  const { setFormProgress, formProgress } = props
-
   const setLocal = () => {
-    setFormProgress(formProgress + 1)
     swiper.slideNext()
   }
   return (
@@ -121,7 +88,7 @@ export function WelcomeView(props) {
           height: '300px',
           borderRadius: '24px',
         }}
-        image={props.image}
+        image={image}
       />
       <Stack
         sx={{
@@ -170,22 +137,25 @@ export function WindowView(props) {
 }
 
 export function InputSelectView(props) {
-  const { multi, value, options } = props
+  const { value, options } = props
   const classes = useClasses(styles)
+  const [data, setData] = useState([])
 
   const cols = props.cols ? props.cols : 1
 
-  const [data, setData] = useState(multi ? [] : '')
-
   function onChange(e) {
-    multi
-      ? !data.includes(e.target.value)
-        ? setData([...data, e.target.value])
-        : setData(data.filter((x) => x !== e.target.value))
-      : setData(e.target.value)
+    let arr
+    if (!data.includes(e.target.value)) {
+      arr = [...data, e.target.value]
+      setData(arr)
+    } else {
+      arr = data.filter((x) => x !== e.target.value)
+      setData(arr)
+    }
+    localStorage.setItem(value, arr)
   }
 
-  return multi ? (
+  return (
     <Box>
       <TitleSection value={value} />
       <Grid
@@ -220,41 +190,7 @@ export function InputSelectView(props) {
               className={data.includes(val) ? 'active' : ''}
             >
               {val}
-              <Check />
-            </Button>
-          </Box>
-        ))}
-      </Grid>
-    </Box>
-  ) : (
-    <Box>
-      <Grid container style={{ gap: '10px', justifyContent: 'space-between' }}>
-        {options?.map((val, i) => (
-          <Box
-            as="div"
-            key={i}
-            className={classes.btnInput}
-            sx={{
-              flex: `0 1 calc(calc(100% / ${cols}) - (10px * ${cols - 1}))`,
-            }}
-          >
-            <input
-              onChange={onChange}
-              type="radio"
-              value={val}
-              name={value}
-              id={val}
-              hidden
-            />
-            <Button
-              variant="selection"
-              component="label"
-              fullWidth
-              htmlFor={val}
-              size="small"
-            >
-              {val}
-              <Check />
+              {data.includes(val) ? <Check /> : null}
             </Button>
           </Box>
         ))}
@@ -269,9 +205,15 @@ export function InputPillView(props) {
   const [data, setData] = useState([])
 
   function onChange(val) {
-    !data.includes(val)
-      ? setData([...data, val])
-      : setData(data.filter((x) => x !== val))
+    let arr
+    if (!data.includes(val)) {
+      arr = [...data, val]
+      setData(arr)
+    } else {
+      arr = data.filter((x) => x !== val)
+      setData(arr)
+    }
+    localStorage.setItem(value, arr)
   }
 
   return (
@@ -308,20 +250,29 @@ export function InputPillView(props) {
   )
 }
 
-export function InputTextView(props) {
+export function InputTextView({ value }) {
   const classes = useClasses(styles)
   const [data, setData] = useState('')
+
   function onChange(e) {
-    setData(e.target.value)
+    const val = e.target.value
+    setData(val)
+    localStorage.setItem(value, val)
   }
 
   return (
-    <>
-      <TitleSection value={props.value} />
-      <Grid container item className={classes.gridColumn} onChange={onChange}>
+    <Box>
+      <TitleSection value={value} />
+      <Grid
+        container
+        item
+        className={classes.gridColumn}
+        onChange={onChange}
+        sx={{ padding: '1.5em' }}
+      >
         <TextField variant="outlined" fullWidth />
       </Grid>
-    </>
+    </Box>
   )
 }
 
@@ -340,7 +291,9 @@ export function InputSearchView(props) {
     setInputValue(e.target.value)
   }
   function onChange(e) {
+    const val = e.target.value
     setData(e.target.value)
+    localStorage.setItem(value, val)
   }
   const Row = ({ data, index, style, e }) => (
     <div>

--- a/src/components/SignUp/ContinueButtons.tsx
+++ b/src/components/SignUp/ContinueButtons.tsx
@@ -1,0 +1,55 @@
+import React from 'react'
+import { Container, Box, Button, Stack } from '@mui/material'
+import { SwiperNext } from './Swipers'
+import { useSwipe } from './Swipers'
+import { useTranslation } from 'react-i18next'
+
+interface ContinueButtonProps {
+  translationKeys: string[]
+  numOfSlides: number
+  welcomeLength: number
+}
+
+export const ContinueButtons = ({
+  translationKeys,
+  numOfSlides,
+  welcomeLength,
+}: ContinueButtonProps) => {
+  const { t } = useTranslation()
+
+  const { active, swiper } = useSwipe()
+  const emailSlideIndex = 8
+  const interestsSlideIndex = 7
+  return (
+    <Container slot={'container-end'}>
+      <Box
+        sx={{
+          display: 'flext',
+          alignItems: 'center',
+          justifyContent: 'center',
+          margin: '0 .25em',
+        }}
+      >
+        <Stack
+          spacing={2}
+          sx={{
+            flexDirection: { xs: 'column', md: 'row' },
+          }}
+        >
+          {active > welcomeLength &&
+          active < numOfSlides &&
+          active !== emailSlideIndex ? (
+            <SwiperNext handleClick={() => swiper.slideNext()}>
+              {t('btn.continue')}
+            </SwiperNext>
+          ) : null}
+          {active > welcomeLength && active < interestsSlideIndex ? (
+            <Button variant="text" onClick={() => swiper.slideNext()}>
+              {t(`onboarding.${translationKeys[active - 4]}.skip-btn`)}
+            </Button>
+          ) : null}
+        </Stack>
+      </Box>
+    </Container>
+  )
+}

--- a/src/components/SignUp/Progress.tsx
+++ b/src/components/SignUp/Progress.tsx
@@ -1,5 +1,13 @@
 import React from 'react'
-import { MobileStepper, Container, Link, Typography } from '@mui/material'
+import {
+  MobileStepper,
+  Container,
+  Link,
+  Typography,
+  Box,
+  Button,
+  Stack,
+} from '@mui/material'
 import ArrowBack from '@mui/icons-material/ArrowBack'
 import { SwiperNext, SwiperPrev } from './Swipers'
 import { useSwipe } from './Swipers'
@@ -9,6 +17,10 @@ interface ProgressProps {
   start: number
   end: number
   slot: string
+}
+
+interface ContinueButtonProps {
+  translationKeys: string[]
 }
 
 export const ProgressBar = ({ start, end, slot }: ProgressProps) => {
@@ -81,6 +93,42 @@ export const ProgressDots = (props: ProgressProps) => {
           backButton={undefined}
         />
       ) : null}
+    </Container>
+  )
+}
+
+export const ContinueButtons = ({ translationKeys }: ContinueButtonProps) => {
+  const { t } = useTranslation()
+
+  const { active, swiper } = useSwipe()
+  return (
+    <Container slot={'container-end'}>
+      <Box
+        sx={{
+          display: 'flext',
+          alignItems: 'center',
+          justifyContent: 'center',
+          margin: '0 .25em',
+        }}
+      >
+        <Stack
+          spacing={2}
+          sx={{
+            flexDirection: { xs: 'column', md: 'row' },
+          }}
+        >
+          {active >= 4 && active <= 7 ? (
+            <SwiperNext handleClick={() => swiper.slideNext()}>
+              {t('btn.continue')}
+            </SwiperNext>
+          ) : null}
+          {active >= 4 && active <= 6 ? (
+            <Button variant="text" onClick={() => swiper.slideNext()}>
+              {t(`onboarding.${translationKeys[active - 4]}.skip-btn`)}
+            </Button>
+          ) : null}
+        </Stack>
+      </Box>
     </Container>
   )
 }

--- a/src/components/SignUp/Progress.tsx
+++ b/src/components/SignUp/Progress.tsx
@@ -1,13 +1,5 @@
 import React from 'react'
-import {
-  MobileStepper,
-  Container,
-  Link,
-  Typography,
-  Box,
-  Button,
-  Stack,
-} from '@mui/material'
+import { MobileStepper, Container, Link, Typography } from '@mui/material'
 import ArrowBack from '@mui/icons-material/ArrowBack'
 import { SwiperNext, SwiperPrev } from './Swipers'
 import { useSwipe } from './Swipers'
@@ -17,10 +9,6 @@ interface ProgressProps {
   start: number
   end: number
   slot: string
-}
-
-interface ContinueButtonProps {
-  translationKeys: string[]
 }
 
 export const ProgressBar = ({ start, end, slot }: ProgressProps) => {
@@ -93,42 +81,6 @@ export const ProgressDots = (props: ProgressProps) => {
           backButton={undefined}
         />
       ) : null}
-    </Container>
-  )
-}
-
-export const ContinueButtons = ({ translationKeys }: ContinueButtonProps) => {
-  const { t } = useTranslation()
-
-  const { active, swiper } = useSwipe()
-  return (
-    <Container slot={'container-end'}>
-      <Box
-        sx={{
-          display: 'flext',
-          alignItems: 'center',
-          justifyContent: 'center',
-          margin: '0 .25em',
-        }}
-      >
-        <Stack
-          spacing={2}
-          sx={{
-            flexDirection: { xs: 'column', md: 'row' },
-          }}
-        >
-          {active >= 4 && active <= 7 ? (
-            <SwiperNext handleClick={() => swiper.slideNext()}>
-              {t('btn.continue')}
-            </SwiperNext>
-          ) : null}
-          {active >= 4 && active <= 6 ? (
-            <Button variant="text" onClick={() => swiper.slideNext()}>
-              {t(`onboarding.${translationKeys[active - 4]}.skip-btn`)}
-            </Button>
-          ) : null}
-        </Stack>
-      </Box>
     </Container>
   )
 }

--- a/src/components/SignUp/SignUpSection.tsx
+++ b/src/components/SignUp/SignUpSection.tsx
@@ -22,7 +22,7 @@ import juggling from 'assets/images/juggling.png'
 import gardening from 'assets/images/gardening.png'
 import toolbelt from 'assets/images/toolbelt.png'
 import { categories } from 'assets/options/categories'
-import { ProgressDots, ProgressBar } from './Progress'
+import { ProgressDots, ProgressBar, ContinueButtons } from './Progress'
 
 const SlotStart = 'container-start'
 const SlotEnd = 'container-end'
@@ -34,11 +34,17 @@ function SignUpSection() {
   const [formProgress, setFormProgress] = useState(0)
 
   const categoryOptions = categories.slice(1).map(({ label }) => label)
-
+  const translationKeys = [
+    'fnmi',
+    'language',
+    'school',
+    'interests',
+    'displayName',
+  ]
   return (
     <Section size="auto">
-      <Swiper modules={[A11y, Keyboard]} autoHeight={true}>
-        <SwiperSlide style={{ height: '600px' }}>
+      <Swiper modules={[A11y, Keyboard]}>
+        <SwiperSlide>
           <WelcomeView
             image={welcome}
             formProgress={formProgress}
@@ -107,18 +113,16 @@ function SignUpSection() {
 
         <SwiperSlide>
           <InputTextView
-            value="displayName"
+            value="screen-6"
             formProgress={formProgress}
             setFormProgress={setFormProgress}
           />
         </SwiperSlide>
 
         <SwiperSlide>
-          <FinishView
-            values={['fnmi', 'language', 'school', 'interests', 'displayName']}
-          />
+          <FinishView values={translationKeys} />
         </SwiperSlide>
-
+        <ContinueButtons translationKeys={translationKeys} />
         <ProgressDots start={1} end={welcomeLength} slot={SlotEnd} />
       </Swiper>
     </Section>

--- a/src/components/SignUp/SignUpSection.tsx
+++ b/src/components/SignUp/SignUpSection.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React from 'react'
 import Section from '../Section'
 import { useTranslation } from 'react-i18next'
 import { A11y, Keyboard } from 'swiper'
@@ -22,39 +22,39 @@ import juggling from 'assets/images/juggling.png'
 import gardening from 'assets/images/gardening.png'
 import toolbelt from 'assets/images/toolbelt.png'
 import { categories } from 'assets/options/categories'
-import { ProgressDots, ProgressBar, ContinueButtons } from './Progress'
+import { ProgressDots, ProgressBar } from './Progress'
+import { ContinueButtons } from './ContinueButtons'
 
 const SlotStart = 'container-start'
 const SlotEnd = 'container-end'
 
 function SignUpSection() {
   const { t } = useTranslation()
-  const welcomeLength = 3
-  const inputLength = 4
-  const [formProgress, setFormProgress] = useState(0)
-
-  const categoryOptions = categories.slice(1).map(({ label }) => label)
   const translationKeys = [
     'fnmi',
     'language',
     'school',
     'interests',
+    'email',
     'displayName',
   ]
+  const categoryOptions = categories.slice(1).map(({ label }) => label)
+
+  const fnmiOptions = ['Inuit', 'Métis', 'First Nations', 'None of the above']
+  const languageOptions = ['Cree', 'Inuktitut', 'Ojibwe', 'English']
+  const welcomeLength = 3
+  const progressSlides = 7
+
   return (
     <Section size="auto">
       <Swiper modules={[A11y, Keyboard]}>
         <SwiperSlide>
-          <WelcomeView
-            image={welcome}
-            formProgress={formProgress}
-            setFormProgress={setFormProgress}
-          />
+          <WelcomeView image={welcome} />
         </SwiperSlide>
 
         <ProgressBar
           start={welcomeLength}
-          end={welcomeLength + inputLength + 1}
+          end={progressSlides + welcomeLength}
           slot={SlotStart}
         />
         <SwiperSlide>
@@ -71,40 +71,21 @@ function SignUpSection() {
 
         {/* Input Views */}
         <SwiperSlide>
-          <InputSelectView
-            value="fnmi"
-            options={['Inuit', 'Métis', 'First Nations', 'None of the above']}
-            formProgress={formProgress}
-            setFormProgress={setFormProgress}
-            multi
-          />
+          <InputSelectView value="fnmi" options={fnmiOptions} />
         </SwiperSlide>
 
         <SwiperSlide>
-          <InputSelectView
-            value="language"
-            options={['Cree', 'Inuktitut', 'Ojibwe', 'English']}
-            formProgress={formProgress}
-            setFormProgress={setFormProgress}
-            multi
-          />
+          <InputSelectView value="language" options={languageOptions} />
         </SwiperSlide>
 
         <SwiperSlide>
           <InputSearchView
             value="school"
             options={schoolData.map((x: any) => x.School)}
-            formProgress={formProgress}
-            setFormProgress={setFormProgress}
           />
         </SwiperSlide>
         <SwiperSlide>
-          <InputPillView
-            value="interests"
-            options={categoryOptions}
-            formProgress={formProgress}
-            setFormProgress={setFormProgress}
-          />
+          <InputPillView value="interests" options={categoryOptions} />
         </SwiperSlide>
 
         <SwiperSlide>
@@ -112,17 +93,17 @@ function SignUpSection() {
         </SwiperSlide>
 
         <SwiperSlide>
-          <InputTextView
-            value="screen-6"
-            formProgress={formProgress}
-            setFormProgress={setFormProgress}
-          />
+          <InputTextView value="displayName" />
         </SwiperSlide>
 
         <SwiperSlide>
           <FinishView values={translationKeys} />
         </SwiperSlide>
-        <ContinueButtons translationKeys={translationKeys} />
+        <ContinueButtons
+          translationKeys={translationKeys}
+          numOfSlides={progressSlides + welcomeLength}
+          welcomeLength={welcomeLength}
+        />
         <ProgressDots start={1} end={welcomeLength} slot={SlotEnd} />
       </Swiper>
     </Section>


### PR DESCRIPTION
[TIG-203-bug-with-onbarding-slides](https://app.clickup.com/9009201449/inbox?tab=important)

* This fixes the bug with onboarding slides for _almost_ all slides.  After a client clicks 'get started' from the first slide then click away, when they come back they will be asked to click 'get started' once more to begin onboarding.
* Also, some cleanup has been done to make sure state is being set correctly for each slide.
* Translations have been to added to match the design.
* The progress bar now correctly reflects where your progress is in the onboarding process.
* Interests are now saved once the onboarding process has been completed.
* The slides themselves look essentially the same other than the 'continue' button is a little bit lower on the screen to match the design more closely.
https://www.figma.com/file/57iO7pHS19ZVWR3RewN7As/C2L%3A-Prototype-01-(Discover-%26-Onboard)?type=design&node-id=0-1&mode=design&t=u0g8RrFaQ1sy56B8-0

![Screenshot from 2024-01-27 20-50-17](https://github.com/TakingITGlobal/create-to-learn/assets/14957396/0c546233-be1c-4982-9c88-e65b70383796)
