### PR TITLE
[Tig 552] - Setting transitions

### DIFF
--- a/src/components/Settings/SettingsCommunity.js
+++ b/src/components/Settings/SettingsCommunity.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
 
 import Typography from '@mui/material/Typography'
+import Slide from '@mui/material/Slide'
 import Button from '@mui/material/Button'
 import Box from '@mui/material/Box'
 import List from '@mui/material/List'
@@ -47,110 +48,118 @@ function SettingsCommunity({ showComponent, setShowComponent }) {
 
   return (
     showComponent === 'communities' && (
-      <Box
-        sx={{
-          display: 'flex',
-          flexDirection: 'column',
-          height: '700px',
-        }}
+      <Slide
+      direction="left"
+      in={showComponent}
+      timeout={500}
+      mountOnEnter
+      unmountOnExit
       >
-        <Box sx={{ padding: '1.5rem 0' }}>
-          <Typography variant="h5" fontWeight={700} color={'lavender'} sx={{ paddingBottom: '10px' }}>
-            I am ...
-          </Typography>
-          <Typography>
-            Tell us more about you, so we can personalize your experience.
-          </Typography>
-        </Box>
-        <List
-          sx={{ width: '100%' }}
-          component="nav"
-          aria-labelledby="settings-profile"
+        <Box
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            height: '700px',
+          }}
         >
-          {culturalGroups.map((community, index) => (
+          <Box sx={{ padding: '1.5rem 0' }}>
+            <Typography variant="h5" fontWeight={700} color={'lavender'} sx={{ paddingBottom: '10px' }}>
+              I am ...
+            </Typography>
+            <Typography>
+              Tell us more about you, so we can personalize your experience.
+            </Typography>
+          </Box>
+          <List
+            sx={{ width: '100%' }}
+            component="nav"
+            aria-labelledby="settings-profile"
+          >
+            {culturalGroups.map((community, index) => (
+              <ListItem
+                key={index}
+                sx={{
+                  backgroundColor: communities.includes(community)
+                    ? '#6956F1'
+                    : '#211E34',
+                  marginBottom: '15px',
+                  borderRadius: '5px',
+                }}
+                secondaryAction={
+                  communities.includes(community) && (
+                    <IconButton size="large">
+                      <CheckCircleIcon />
+                    </IconButton>
+                  )
+                }
+              >
+                <ListItemButton onClick={() => handleCommunity(community)}>
+                  <ListItemText>{community}</ListItemText>
+                </ListItemButton>
+              </ListItem>
+            ))}
             <ListItem
-              key={index}
               sx={{
-                backgroundColor: communities.includes(community)
-                  ? '#6956F1'
-                  : '#211E34',
+                backgroundColor: communities.includes('') ? '#6956F1' : '#211E34',
                 marginBottom: '15px',
                 borderRadius: '5px',
               }}
               secondaryAction={
-                communities.includes(community) && (
+                communities.includes('') && (
                   <IconButton size="large">
                     <CheckCircleIcon />
                   </IconButton>
                 )
               }
             >
-              <ListItemButton onClick={() => handleCommunity(community)}>
-                <ListItemText>{community}</ListItemText>
+              <ListItemButton onClick={() => handleCommunity(NONE_OF_THE_ABOVE)}>
+                <ListItemText>{t('settings.none-of-the-above')}</ListItemText>
               </ListItemButton>
             </ListItem>
-          ))}
-          <ListItem
+            <ListItem
+              sx={{
+                backgroundColor: !communities.length ? '#6956F1' : '#211E34',
+                marginBottom: '15px',
+                borderRadius: '5px',
+              }}
+              secondaryAction={
+                !communities.length && (
+                  <IconButton size="large">
+                    <CheckCircleIcon />
+                  </IconButton>
+                )
+              }
+            >
+              <ListItemButton onClick={() => handleCommunity(PREFER_NOT_TO_SAY)}>
+                <ListItemText>{t('settings.prefer-not-to-say')}</ListItemText>
+              </ListItemButton>
+            </ListItem>
+          </List>
+          <Box
             sx={{
-              backgroundColor: communities.includes('') ? '#6956F1' : '#211E34',
-              marginBottom: '15px',
-              borderRadius: '5px',
-            }}
-            secondaryAction={
-              communities.includes('') && (
-                <IconButton size="large">
-                  <CheckCircleIcon />
-                </IconButton>
-              )
-            }
-          >
-            <ListItemButton onClick={() => handleCommunity(NONE_OF_THE_ABOVE)}>
-              <ListItemText>{t('settings.none-of-the-above')}</ListItemText>
-            </ListItemButton>
-          </ListItem>
-          <ListItem
-            sx={{
-              backgroundColor: !communities.length ? '#6956F1' : '#211E34',
-              marginBottom: '15px',
-              borderRadius: '5px',
-            }}
-            secondaryAction={
-              !communities.length && (
-                <IconButton size="large">
-                  <CheckCircleIcon />
-                </IconButton>
-              )
-            }
-          >
-            <ListItemButton onClick={() => handleCommunity(PREFER_NOT_TO_SAY)}>
-              <ListItemText>{t('settings.prefer-not-to-say')}</ListItemText>
-            </ListItemButton>
-          </ListItem>
-        </List>
-        <Box
-          sx={{
-            display: 'flex',
-            padding: '1.5rem 0',
-            flexGrow: 1,
-            alignItems: 'flex-end',
-          }}
-        >
-          <Button
-            fullWidth
-            color="primary"
-            variant="contained"
-            sx = {{
-              padding: "16px 24px"
-            }}
-            onClick={() => {
-              updateUser(auth.user.uid, { fnmi: communities })
-              setShowComponent('nav')
+              display: 'flex',
+              padding: '1.5rem 0',
+              flexGrow: 1,
+              alignItems: 'flex-end',
             }}
           >
-            {t('settings.update')}
-          </Button>
+            <Button
+              fullWidth
+              color="primary"
+              variant="contained"
+              sx = {{
+                padding: "16px 24px"
+              }}
+              onClick={() => {
+                updateUser(auth.user.uid, { fnmi: communities })
+                setShowComponent('nav')
+              }}
+            >
+              {t('settings.update')}
+            </Button>
+          </Box>
         </Box>
-      </Box>
+      </Slide>
     )
   )
 }

--- a/src/components/Settings/SettingsDeleteAccount.js
+++ b/src/components/Settings/SettingsDeleteAccount.js
@@ -4,6 +4,7 @@ import Button from '@mui/material/Button'
 import Box from '@mui/material/Box'
 import Grid from '@mui/material/Grid'
 import Dialog from '@mui/material/Dialog'
+import Slide from '@mui/material/Slide'
 
 import { useTranslation } from 'react-i18next'
 import { deleteUser } from '../../util/db'
@@ -17,125 +18,133 @@ function SettingsDeleteAccount({ showComponent, setShowComponent }) {
   //   const [confirmDeletedDialog, setConfirmDeletedDialog] = useState(false)
   return (
     showComponent === 'deleteAccount' && (
-      <Box
-        sx={{
-          display: 'flex',
-          flexDirection: 'column',
-          height: '700px',
-        }}
+      <Slide
+      direction="left"
+      in={showComponent}
+      timeout={500}
+      mountOnEnter
+      unmountOnExit
       >
-        <Box sx={{ padding: '1.5rem 0' }}>
-          <Typography variant="h6" fontWeight={700} color={'lavender'}>
-            {t('settings.delete-your-account')}
-          </Typography>
-          <Typography variant="body1">
-            Info about deleting your account. Lorem ipsum dolor sit amet,
-            consectetur adipiscing elit. Nunc vulputate libero et velit
-            interdum, ac aliquet odio mattis.
-          </Typography>
-        </Box>
         <Box
           sx={{
             display: 'flex',
-            padding: '1.5rem 0',
-            flexGrow: 1,
-            alignItems: 'flex-end',
-          }}
-        >
-          <Button 
-            sx = {{
-              padding: "16px 24px"
-            }}
-            fullWidth 
-            onClick={() => setDialog(true)} 
-            color="error">
-            {t('settings.delete-account')}
-          </Button>
-        </Box>
-        <Dialog onClose={() => setDialog(false)} open={dialog}>
-          <Box 
-          sx = {{
-            display: 'flex',
             flexDirection: 'column',
-            padding: '16px 0',
-            textAlign: 'center',
-          }}
-          >
-            <Box sx={{ paddingBottom: '16px' }}>
-              <Typography variant="h3">{t('settings.confirm-delete')}</Typography>
-            </Box>
-            <Box sx={{ paddingBottom: '20px', textAlign: 'center' }}>
-              <Typography variant="body2" color="text.secondary">
-                {t('settings.are-you-sure')}
-              </Typography>
-            </Box>
-            <Grid container>
-              <Grid item xs={6}>
-                <Button
-                  variant="text"
-                  size="large"
-                  fullWidth
-                  sx = {{
-                    padding: "8px",
-                    borderRadius: "25px",
-                    fontWeight: "500",
-                    textTransform: "none"
-                  }}
-                  onClick={() => {
-                    deleteUser(auth.user.uid)
-                    auth.signout()
-                    // setConfirmDeletedDialog(true)
-                  }}
-                >
-                  {t('settings.yes-delete')}
-                </Button>
-              </Grid>
-              <Grid item xs={6}>
-                <Button
-                  variant="contained"
-                  size="large"
-                  sx = {{
-                    padding: "8px"
-                  }}
-                  fullWidth
-                  onClick={() => setDialog(false)}
-                >
-                  {t('cancel')}
-                </Button>
-              </Grid>
-            </Grid>
-            </Box>
-        </Dialog>
-        {/* To do: local storage has to be cleared when deleting a user and
-      defaults to the login screen. // Would love to be able to show the
-      'account deleted successful' instead of defaulting to the login */}
-        {/* <Dialog
-        onClose={() => setConfirmDeletedDialog(false)}
-        open={confirmDeletedDialog}
-      >
-        <Box sx={{ paddingBottom: '10px' }}>
-          <Typography variant="h3" sx={{ color: 'white' }}>
-            {t('settings.account-deleted')}
-          </Typography>
-        </Box>
-        <Box sx={{ paddingBottom: '20px', textAlign: 'center' }}>
-          <Typography variant="body2" color="text.secondary">
-            {t('settings.account-deleted-success')}
-          </Typography>
-        </Box>
-        <Button
-          variant="text"
-          size="large"
-          fullWidth
-          onClick={() => {
-            auth.signout()
-            setShowComponent('nav')
+            height: '700px',
           }}
         >
-          {t('settings.okay-got-it')}
-        </Button>
-      </Dialog> */}
-      </Box>
+          <Box sx={{ padding: '1.5rem 0' }}>
+            <Typography variant="h6" fontWeight={700} color={'lavender'}>
+              {t('settings.delete-your-account')}
+            </Typography>
+            <Typography variant="body1">
+              Info about deleting your account. Lorem ipsum dolor sit amet,
+              consectetur adipiscing elit. Nunc vulputate libero et velit
+              interdum, ac aliquet odio mattis.
+            </Typography>
+          </Box>
+          <Box
+            sx={{
+              display: 'flex',
+              padding: '1.5rem 0',
+              flexGrow: 1,
+              alignItems: 'flex-end',
+            }}
+          >
+            <Button 
+              sx = {{
+                padding: "16px 24px"
+              }}
+              fullWidth 
+              onClick={() => setDialog(true)} 
+              color="error">
+              {t('settings.delete-account')}
+            </Button>
+          </Box>
+          <Dialog onClose={() => setDialog(false)} open={dialog}>
+            <Box 
+            sx = {{
+              display: 'flex',
+              flexDirection: 'column',
+              padding: '16px 0',
+              textAlign: 'center',
+            }}
+            >
+              <Box sx={{ paddingBottom: '16px' }}>
+                <Typography variant="h3">{t('settings.confirm-delete')}</Typography>
+              </Box>
+              <Box sx={{ paddingBottom: '20px', textAlign: 'center' }}>
+                <Typography variant="body2" color="text.secondary">
+                  {t('settings.are-you-sure')}
+                </Typography>
+              </Box>
+              <Grid container>
+                <Grid item xs={6}>
+                  <Button
+                    variant="text"
+                    size="large"
+                    fullWidth
+                    sx = {{
+                      padding: "8px",
+                      borderRadius: "25px",
+                      fontWeight: "500",
+                      textTransform: "none"
+                    }}
+                    onClick={() => {
+                      deleteUser(auth.user.uid)
+                      auth.signout()
+                      // setConfirmDeletedDialog(true)
+                    }}
+                  >
+                    {t('settings.yes-delete')}
+                  </Button>
+                </Grid>
+                <Grid item xs={6}>
+                  <Button
+                    variant="contained"
+                    size="large"
+                    sx = {{
+                      padding: "8px"
+                    }}
+                    fullWidth
+                    onClick={() => setDialog(false)}
+                  >
+                    {t('cancel')}
+                  </Button>
+                </Grid>
+              </Grid>
+              </Box>
+          </Dialog>
+          {/* To do: local storage has to be cleared when deleting a user and
+        defaults to the login screen. // Would love to be able to show the
+        'account deleted successful' instead of defaulting to the login */}
+          {/* <Dialog
+          onClose={() => setConfirmDeletedDialog(false)}
+          open={confirmDeletedDialog}
+        >
+          <Box sx={{ paddingBottom: '10px' }}>
+            <Typography variant="h3" sx={{ color: 'white' }}>
+              {t('settings.account-deleted')}
+            </Typography>
+          </Box>
+          <Box sx={{ paddingBottom: '20px', textAlign: 'center' }}>
+            <Typography variant="body2" color="text.secondary">
+              {t('settings.account-deleted-success')}
+            </Typography>
+          </Box>
+          <Button
+            variant="text"
+            size="large"
+            fullWidth
+            onClick={() => {
+              auth.signout()
+              setShowComponent('nav')
+            }}
+          >
+            {t('settings.okay-got-it')}
+          </Button>
+        </Dialog> */}
+        </Box>
+      </Slide>
     )
   )
 }

--- a/src/components/Settings/SettingsDisplayName.js
+++ b/src/components/Settings/SettingsDisplayName.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react';
 
 import Typography from '@mui/material/Typography'
 import Button from '@mui/material/Button'
@@ -9,14 +9,24 @@ import { updateUser } from '../../util/db'
 import { useTranslation } from 'react-i18next'
 import { useAuth } from '../../util/auth'
 
+import Slide from '@mui/material/Slide'
+
 function SettingsDisplayName({ showComponent, setShowComponent }) {
   const { t } = useTranslation()
   const auth = useAuth()
 
   const [name, setName] = useState(auth.user.displayName ?? auth.user.name)
 
+
   return (
     showComponent === 'displayName' && (
+      <Slide
+      direction="left"
+      in={showComponent === 'displayName'}
+      timeout={600}
+      mountOnEnter
+      unmountOnExit
+    >
       <Box
         sx={{
           display: 'flex',
@@ -29,6 +39,7 @@ function SettingsDisplayName({ showComponent, setShowComponent }) {
             {t('settings.change-display-name')}
           </Typography>
         </Box>
+        
         <TextField
           id="displayName"
           variant="outlined"
@@ -59,6 +70,7 @@ function SettingsDisplayName({ showComponent, setShowComponent }) {
           </Button>
         </Box>
       </Box>
+    </Slide>
     )
   )
 }

--- a/src/components/Settings/SettingsEmail.js
+++ b/src/components/Settings/SettingsEmail.js
@@ -6,6 +6,8 @@ import TextField from '@mui/material/TextField'
 
 import { useTranslation } from 'react-i18next'
 
+import Slide from '@mui/material/Slide'
+
 function SettingsEmail({ auth, showComponent, setShowComponent }) {
   const { t } = useTranslation()
 
@@ -13,6 +15,13 @@ function SettingsEmail({ auth, showComponent, setShowComponent }) {
 
   return (
     showComponent === 'email' && (
+    <Slide
+      direction="left"
+      in={showComponent}
+      timeout={500}
+      mountOnEnter
+      unmountOnExit
+    >
       <Box
         sx={{
           display: 'flex',
@@ -50,6 +59,7 @@ function SettingsEmail({ auth, showComponent, setShowComponent }) {
           </Button>
         </Box>
       </Box>
+    </Slide>
     )
   )
 }

--- a/src/components/Settings/SettingsInterests.js
+++ b/src/components/Settings/SettingsInterests.js
@@ -4,6 +4,7 @@ import Button from '@mui/material/Button'
 import Box from '@mui/material/Box'
 import Chip from '@mui/material/Chip'
 import Stack from '@mui/material/Stack'
+import Slide from '@mui/material/Slide'
 
 import { categories } from '../../assets/options/categories'
 import { useAuth } from '../../util/auth'
@@ -25,68 +26,76 @@ function SettingsInterests({ showComponent, setShowComponent }) {
 
   return (
     showComponent === 'interests' && (
-      <Box
-        sx={{
-          display: 'flex',
-          flexDirection: 'column',
-          height: '700px',
-        }}
+      <Slide
+      direction="left"
+      in={showComponent}
+      timeout={500}
+      mountOnEnter
+      unmountOnExit
       >
-        <Box>
-          <Box sx={{ padding: '1.5rem 0' }}>
-            <Typography variant="h6" color={'lavender'} fontWeight='700'>I'm interested in...</Typography>
-            <Typography>Pick up to three topics you're interested in</Typography>
-          </Box>
-          <Stack direction="row" spacing={2} useFlexGap flexWrap="wrap">
-            {clippedCategories.splice(1).map((category, index) => {
-              const clicked = interests.includes(category.label)
-              return (
-                <Chip
-                  key={index}
-                  label={category.label}
-                  clickable
-                  disabled={
-                    interests.length === 3 &&
-                    !interests.includes(category.label)
-                  }
-                  onClick={() => handleInterests(category.label)}
-                  sx={{
-                    fontSize: 16,
-                    fontWeight: clicked? '700' : '',
-                    marginLeft: 0,
-                    padding: '10px 0',
-                    backgroundColor: clicked ? '#6956F1' : '#211E34',
-                  }}
-                  variant="default"
-                />
-              )
-            })}
-          </Stack>
-        </Box>
         <Box
           sx={{
             display: 'flex',
-            padding: '1.5rem 0',
-            flexGrow: 1,
-            alignItems: 'flex-end',
+            flexDirection: 'column',
+            height: '700px',
           }}
         >
-          <Button
-            fullWidth
-            color="primary"
-            variant="contained"
-            sx = {{
-              padding: "16px 24px"
-            }}
-            onClick={() => {
-              updateUser(auth.user.uid, { interests: interests })
-              setShowComponent('nav')
+          <Box>
+            <Box sx={{ padding: '1.5rem 0' }}>
+              <Typography variant="h6" color={'lavender'} fontWeight='700'>I'm interested in...</Typography>
+              <Typography>Pick up to three topics you're interested in</Typography>
+            </Box>
+            <Stack direction="row" spacing={2} useFlexGap flexWrap="wrap">
+              {clippedCategories.splice(1).map((category, index) => {
+                const clicked = interests.includes(category.label)
+                return (
+                  <Chip
+                    key={index}
+                    label={category.label}
+                    clickable
+                    disabled={
+                      interests.length === 3 &&
+                      !interests.includes(category.label)
+                    }
+                    onClick={() => handleInterests(category.label)}
+                    sx={{
+                      fontSize: 16,
+                      fontWeight: clicked? '700' : '',
+                      marginLeft: 0,
+                      padding: '10px 0',
+                      backgroundColor: clicked ? '#6956F1' : '#211E34',
+                    }}
+                    variant="default"
+                  />
+                )
+              })}
+            </Stack>
+          </Box>
+          <Box
+            sx={{
+              display: 'flex',
+              padding: '1.5rem 0',
+              flexGrow: 1,
+              alignItems: 'flex-end',
             }}
           >
-            {t('settings.update')}
-          </Button>
+            <Button
+              fullWidth
+              color="primary"
+              variant="contained"
+              sx = {{
+                padding: "16px 24px"
+              }}
+              onClick={() => {
+                updateUser(auth.user.uid, { interests: interests })
+                setShowComponent('nav')
+              }}
+            >
+              {t('settings.update')}
+            </Button>
+          </Box>
         </Box>
-      </Box>
+      </Slide>
     )
   )
 }

--- a/src/components/Settings/SettingsLanguage.js
+++ b/src/components/Settings/SettingsLanguage.js
@@ -10,6 +10,7 @@ import ListItemButton from '@mui/material/ListItemButton'
 import CheckCircleIcon from '@mui/icons-material/CheckCircle'
 import IconButton from '@mui/material/IconButton'
 import ArrowForward from '@mui/icons-material/ArrowForward'
+import Slide from '@mui/material/Slide'
 import { languages as languageOptions } from '../../assets/options/filters'
 
 import { updateUser } from '../../util/db'
@@ -41,97 +42,105 @@ function SettingsLanguage({ showComponent, setShowComponent }) {
 
   return (
     showComponent === 'language' && (
-      <Box
-        sx={{
-          display: 'flex',
-          flexDirection: 'column',
-          height: '700px',
-        }}
+      <Slide
+      direction="left"
+      in={showComponent}
+      timeout={500}
+      mountOnEnter
+      unmountOnExit
       >
-        <Box sx={{ padding: '1.5rem 0'}}>
-          <Typography variant="h5" fontWeight={700} color={'lavender'} sx={{ paddingBottom: '10px' }}>
-            My language is...
-          </Typography>
-          <Typography color={'lavender'}>Or a language I am learning</Typography>
-          <Typography>
-            So that we can greet and congratulate you in the future
-          </Typography>
-        </Box>
-        <List
+        <Box
           sx={{
-            width: '100%',
-            maxHeight: '400px',
-            overflowY: "scroll"
+            display: 'flex',
+            flexDirection: 'column',
+            height: '700px',
           }}
-          component="nav"
-          aria-labelledby="settings-profile"
         >
-          {languageOptions.map((language, index) => (
+          <Box sx={{ padding: '1.5rem 0'}}>
+            <Typography variant="h5" fontWeight={700} color={'lavender'} sx={{ paddingBottom: '10px' }}>
+              My language is...
+            </Typography>
+            <Typography color={'lavender'}>Or a language I am learning</Typography>
+            <Typography>
+              So that we can greet and congratulate you in the future
+            </Typography>
+          </Box>
+          <List
+            sx={{
+              width: '100%',
+              maxHeight: '400px',
+              overflowY: "scroll"
+            }}
+            component="nav"
+            aria-labelledby="settings-profile"
+          >
+            {languageOptions.map((language, index) => (
+              <ListItem
+                key={index}
+                sx={{
+                  backgroundColor: languages.includes(language)
+                    ? '#6956F1'
+                    : '#211E34',
+                  marginBottom: '10px',
+                  borderRadius: '5px',
+                }}
+                secondaryAction={
+                  languages.includes(language) && (
+                    <IconButton size="large">
+                      <CheckCircleIcon />
+                    </IconButton>
+                  )
+                }
+              >
+                <ListItemButton onClick={() => handleLanguages(language)}>
+                  <ListItemText>{language}</ListItemText>
+                </ListItemButton>
+              </ListItem>
+            ))}
             <ListItem
-              key={index}
               sx={{
-                backgroundColor: languages.includes(language)
-                  ? '#6956F1'
-                  : '#211E34',
-                marginBottom: '10px',
+                backgroundColor: !languages.length ? '#6956F1' : '#211E34',
+                marginBottom: '15px',
                 borderRadius: '5px',
               }}
               secondaryAction={
-                languages.includes(language) && (
+                !languages.length && (
                   <IconButton size="large">
                     <CheckCircleIcon />
                   </IconButton>
                 )
               }
             >
-              <ListItemButton onClick={() => handleLanguages(language)}>
-                <ListItemText>{language}</ListItemText>
+              <ListItemButton onClick={() => handleLanguages(LANGUAGE_NOT_HERE)}>
+                <ListItemText>My language is not here</ListItemText>
               </ListItemButton>
             </ListItem>
-          ))}
-          <ListItem
+          </List>
+          <Box
             sx={{
-              backgroundColor: !languages.length ? '#6956F1' : '#211E34',
-              marginBottom: '15px',
-              borderRadius: '5px',
-            }}
-            secondaryAction={
-              !languages.length && (
-                <IconButton size="large">
-                  <CheckCircleIcon />
-                </IconButton>
-              )
-            }
-          >
-            <ListItemButton onClick={() => handleLanguages(LANGUAGE_NOT_HERE)}>
-              <ListItemText>My language is not here</ListItemText>
-            </ListItemButton>
-          </ListItem>
-        </List>
-        <Box
-          sx={{
-            display: 'flex',
-            padding: '1.5rem 0',
-            flexGrow: 1,
-            alignItems: 'flex-end',
-          }}
-        >
-          <Button
-            fullWidth
-            color="primary"
-            variant="contained"
-            sx = {{
-              padding: "16px 24px"
-            }}
-            onClick={() => {
-              updateUser(auth.user.uid, { language: languages })
-              setShowComponent('nav')
+              display: 'flex',
+              padding: '1.5rem 0',
+              flexGrow: 1,
+              alignItems: 'flex-end',
             }}
           >
-            {t('settings.update')}&nbsp;
-          </Button>
+            <Button
+              fullWidth
+              color="primary"
+              variant="contained"
+              sx = {{
+                padding: "16px 24px"
+              }}
+              onClick={() => {
+                updateUser(auth.user.uid, { language: languages })
+                setShowComponent('nav')
+              }}
+            >
+              {t('settings.update')}&nbsp;
+            </Button>
+          </Box>
         </Box>
-      </Box>
+      </Slide>
     )
   )
 }

--- a/src/components/Settings/SettingsLegal.js
+++ b/src/components/Settings/SettingsLegal.js
@@ -11,6 +11,7 @@ import ChevronRightIcon from '@mui/icons-material/ChevronRight'
 import ArrowBack from '../ArrowBack'
 import LinkComp from '@mui/material/Link'
 import { useAuth } from '../../util/auth'
+import Slide from '@mui/material/Slide'
 
 import SettingsTermsOfService from './SettingsTermsOfService'
 
@@ -86,7 +87,13 @@ export default SettingsLegal
 
 function LegalNav({ setShowComponent }) {
   return (
-    <>
+    <Slide
+    direction="left"
+    in={setShowComponent}
+    timeout={600}
+    mountOnEnter
+    unmountOnExit
+    >
       <List>
         <Typography variant="h6" padding="12px">Legal</Typography>
         <ListItem
@@ -155,114 +162,138 @@ function LegalNav({ setShowComponent }) {
           </ListItemSecondaryAction>
         </ListItem>
       </List>
-    </>
+    </Slide>
   )
 }
 
 function AboutCreateToLearn({ setShowComponent }) {
   return (
-    <Box
-      sx={{
-        display: 'flex',
-        flexDirection: 'column',
-      }}
+    <Slide
+    direction="left"
+    in={setShowComponent}
+    timeout={600}
+    mountOnEnter
+    unmountOnExit
     >
-      <Box sx={{ padding: '1.5rem 0' }}>
-        <Typography variant="h6">Create to Learn</Typography>
-      </Box>
-      <Box sx={{ paddingBottom: '1rem' }}>
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+        }}
+      >
+        <Box sx={{ padding: '1.5rem 0' }}>
+          <Typography variant="h6">Create to Learn</Typography>
+        </Box>
+        <Box sx={{ paddingBottom: '1rem' }}>
+          <Typography>
+            Create to Learn App Content: Fringilla urna porttitor rhoncus dolor
+            purus non enim. Suscipit tellus mauris a diam maecenas sed enim ut.
+            Diam sollicitudin tempor id eu. Nisi scelerisque eu ultrices vitae
+            auctor. Diam phasellus vestibulum lorem sed risus ultricies tristique
+            nulla. Orci phasellus egestas tellus rutrum. Volutpat sed cras ornare
+            arcu dui vivamus arcu felis bibendum. Cras sed felis eget velit
+            aliquet sagittis id consectetur purus.
+          </Typography>
+        </Box>
+
         <Typography>
-          Create to Learn App Content: Fringilla urna porttitor rhoncus dolor
-          purus non enim. Suscipit tellus mauris a diam maecenas sed enim ut.
-          Diam sollicitudin tempor id eu. Nisi scelerisque eu ultrices vitae
-          auctor. Diam phasellus vestibulum lorem sed risus ultricies tristique
-          nulla. Orci phasellus egestas tellus rutrum. Volutpat sed cras ornare
-          arcu dui vivamus arcu felis bibendum. Cras sed felis eget velit
-          aliquet sagittis id consectetur purus.
+          Magna fermentum iaculis eu non diam phasellus vestibulum lorem. Enim
+          nunc faucibus a pellentesque sit amet porttitor eget dolor. Eget est
+          lorem ipsum dolor sit. Fames ac turpis egestas integer eget aliquet nibh
+          praesent. Velit aliquet sagittis id consectetur purus ut faucibus. Ipsum
+          suspendisse ultrices gravida dictum fusce. Sit amet venenatis urna
+          cursus eget nunc scelerisque viverra. Viverra nibh cras pulvinar mattis
+          nunc sed blandit.
         </Typography>
       </Box>
-
-      <Typography>
-        Magna fermentum iaculis eu non diam phasellus vestibulum lorem. Enim
-        nunc faucibus a pellentesque sit amet porttitor eget dolor. Eget est
-        lorem ipsum dolor sit. Fames ac turpis egestas integer eget aliquet nibh
-        praesent. Velit aliquet sagittis id consectetur purus ut faucibus. Ipsum
-        suspendisse ultrices gravida dictum fusce. Sit amet venenatis urna
-        cursus eget nunc scelerisque viverra. Viverra nibh cras pulvinar mattis
-        nunc sed blandit.
-      </Typography>
-    </Box>
+    </Slide>
   )
 }
 
 function PrivacyPolicy({ setShowComponent }) {
   return (
-    <Box
-      sx={{
-        display: 'flex',
-        flexDirection: 'column',
-      }}
+    <Slide
+    direction="left"
+    in={setShowComponent}
+    timeout={600}
+    mountOnEnter
+    unmountOnExit
     >
-      <Box sx={{ padding: '1.5rem 0' }}>
-        <Typography variant="h6">Privacy Policy</Typography>
-      </Box>
-      <Box sx={{ paddingBottom: '1rem' }}>
-        <Typography>Effective: January 7th, 2021 </Typography>
-      </Box>
-      <Box sx={{ paddingBottom: '1rem' }}>
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+        }}
+      >
+        <Box sx={{ padding: '1.5rem 0' }}>
+          <Typography variant="h6">Privacy Policy</Typography>
+        </Box>
+        <Box sx={{ paddingBottom: '1rem' }}>
+          <Typography>Effective: January 7th, 2021 </Typography>
+        </Box>
+        <Box sx={{ paddingBottom: '1rem' }}>
+          <Typography>
+            This privacy policy describes how TakingITGlobal ("we", "us" or "our")
+            collects, uses and discloses personal information in the course of
+            operating our organization, including in connection with administering
+            programs and services and operating our websites at www.tigweb.org,
+            www.tiged.org, www.risingyouth.ca, www.whose.land, www.codetolearn.ca,
+            www.connectednorth.org, www.youthmovements.org,
+            www.youthleadershipfund.org, and any other TakingITGlobal or partner
+            web sites that link to this Privacy Policy. It also describes the
+            choices available to you regarding our use of your personal
+            information and how you can access and update this information.
+          </Typography>
+        </Box>
+
         <Typography>
-          This privacy policy describes how TakingITGlobal ("we", "us" or "our")
-          collects, uses and discloses personal information in the course of
-          operating our organization, including in connection with administering
-          programs and services and operating our websites at www.tigweb.org,
-          www.tiged.org, www.risingyouth.ca, www.whose.land, www.codetolearn.ca,
-          www.connectednorth.org, www.youthmovements.org,
-          www.youthleadershipfund.org, and any other TakingITGlobal or partner
-          web sites that link to this Privacy Policy. It also describes the
-          choices available to you regarding our use of your personal
-          information and how you can access and update this information.
+          <b>1. Personal Information Collection and Use</b>
+        </Typography>
+        <Typography>
+          This Privacy Policy covers TakingITGlobal's treatment of personally
+          identifiable information that we collect when you are on the
+          TakingITGlobal site or when you use TakingITGlobal's services online.
+          Becoming a Member. TakingITGlobal collects personal information when you
+          register as a TakingITGlobal member. The information we collect when you
+          register includes your name, e- mail address, city, state/province, and
+          country,
         </Typography>
       </Box>
-
-      <Typography>
-        <b>1. Personal Information Collection and Use</b>
-      </Typography>
-      <Typography>
-        This Privacy Policy covers TakingITGlobal's treatment of personally
-        identifiable information that we collect when you are on the
-        TakingITGlobal site or when you use TakingITGlobal's services online.
-        Becoming a Member. TakingITGlobal collects personal information when you
-        register as a TakingITGlobal member. The information we collect when you
-        register includes your name, e- mail address, city, state/province, and
-        country,
-      </Typography>
-    </Box>
+    </Slide>
   )
 }
 
 function AboutOrganization({ setShowComponent }) {
   return (
-    <Box
-      sx={{
-        display: 'flex',
-        flexDirection: 'column',
-      }}
+    <Slide
+    direction="left"
+    in={setShowComponent}
+    timeout={600}
+    mountOnEnter
+    unmountOnExit
     >
-      <Box sx={{ padding: '1.5rem 0' }}>
-        <Typography variant="h6">About Taking It Global</Typography>
-      </Box>
-      <Box sx={{ paddingBottom: '1rem' }}>
-        <Typography>
-          TakingITGlobal empowers youth to understand and act on local and
-          global challenges.
-        </Typography>
-      </Box>
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+        }}
+      >
+        <Box sx={{ padding: '1.5rem 0' }}>
+          <Typography variant="h6">About Taking It Global</Typography>
+        </Box>
+        <Box sx={{ paddingBottom: '1rem' }}>
+          <Typography>
+            TakingITGlobal empowers youth to understand and act on local and
+            global challenges.
+          </Typography>
+        </Box>
 
-      <Box>
-        <LinkComp href="https://www.tigweb.org">
-          Check more on tigweb.org
-        </LinkComp>
+        <Box>
+          <LinkComp href="https://www.tigweb.org">
+            Check more on tigweb.org
+          </LinkComp>
+        </Box>
       </Box>
-    </Box>
+  </Slide>
   )
 }

--- a/src/components/Settings/SettingsMyAccount.js
+++ b/src/components/Settings/SettingsMyAccount.js
@@ -15,10 +15,17 @@ import { Typography } from '@mui/material'
 import { useAuth } from '../../util/auth'
 import { requireAuth } from '../../util/auth'
 
+import Slide from '@mui/material/Slide';
+
+
 function SettingsMyAccount(props) {
   const auth = useAuth()
 
   const [showComponent, setShowComponent] = useState('nav');
+
+
+  console.log('showComponent value:', showComponent);
+
 
   const myAccountLinks = [
     {
@@ -54,12 +61,12 @@ function SettingsMyAccount(props) {
   //ToDo: Make showComponent a custom hook so that we don't have to pass it in like this to each component.
 
   return (
-    <>
+      <>
       <Container sx={{
         display: 'flex', 
         justifyContent:'space-between',
         alignItems: 'center',
-        padding: '52px 0 34px 0'
+        padding: '52px 0 34px 0',
         }}>
         <ArrowBack
           showComponent={showComponent}
@@ -69,45 +76,52 @@ function SettingsMyAccount(props) {
         <div>
         </div>
       </Container>
-      
-      <Container>
-        <MyAccountNav
-          auth={auth}
-          showComponent={showComponent}
-          setShowComponent={setShowComponent}
-        />
-        <SettingsDisplayName
-          auth={auth}
-          showComponent={showComponent}
-          setShowComponent={setShowComponent}
-        />
-        <SettingsEmail
-          auth={auth}
-          showComponent={showComponent}
-          setShowComponent={setShowComponent}
-        />
-        <SettingsSchools
-          showComponent={showComponent}
-          setShowComponent={setShowComponent}
-        />
-        <SettingsInterests
-          showComponent={showComponent}
-          setShowComponent={setShowComponent}
-        />
-        <SettingsLanguage
-          showComponent={showComponent}
-          setShowComponent={setShowComponent}
-        />
-        <SettingsCommunity
-          showComponent={showComponent}
-          setShowComponent={setShowComponent}
-        />
-        <SettingsDeleteAccount
-          auth={auth}
-          showComponent={showComponent}
-          setShowComponent={setShowComponent}
-        />
-      </Container>
+      <Slide
+        direction="left"
+        in={showComponent}
+        timeout={500}
+        mountOnEnter
+        unmountOnExit
+      >
+        <Container>
+          <MyAccountNav
+            auth={auth}
+            showComponent={showComponent}
+            setShowComponent={setShowComponent}
+          />
+          <SettingsDisplayName
+            auth={auth}
+            showComponent={showComponent}
+            setShowComponent={setShowComponent}
+          />
+          <SettingsEmail
+            auth={auth}
+            showComponent={showComponent}
+            setShowComponent={setShowComponent}
+          />
+          <SettingsSchools
+            showComponent={showComponent}
+            setShowComponent={setShowComponent}
+          />
+          <SettingsInterests
+            showComponent={showComponent}
+            setShowComponent={setShowComponent}
+          />
+          <SettingsLanguage
+            showComponent={showComponent}
+            setShowComponent={setShowComponent}
+          />
+          <SettingsCommunity
+            showComponent={showComponent}
+            setShowComponent={setShowComponent}
+          />
+          <SettingsDeleteAccount
+            auth={auth}
+            showComponent={showComponent}
+            setShowComponent={setShowComponent}
+          />
+        </Container>
+      </Slide>
     </>
   )
 }

--- a/src/components/Settings/SettingsSchools.js
+++ b/src/components/Settings/SettingsSchools.js
@@ -3,6 +3,8 @@ import React, { useState, useMemo, useCallback } from 'react'
 import Typography from '@mui/material/Typography'
 import Button from '@mui/material/Button'
 import Box from '@mui/material/Box'
+import Slide from '@mui/material/Slide';
+
 import TextField from '@mui/material/TextField'
 import InputAdornment from '@mui/material/InputAdornment'
 import SearchIcon from '@mui/icons-material/Search'
@@ -60,6 +62,13 @@ function SettingsSchools({ showComponent, setShowComponent }) {
 
   return (
     showComponent === 'school' && (
+      <Slide
+      direction="left"
+      in={showComponent}
+      timeout={500}
+      mountOnEnter
+      unmountOnExit
+    >
       <Box
         sx={{
           display: 'flex',
@@ -134,6 +143,7 @@ function SettingsSchools({ showComponent, setShowComponent }) {
           </Button>
         </Box>
       </Box>
+    </Slide>
     )
   )
 }

--- a/src/components/Settings/SettingsSupport.js
+++ b/src/components/Settings/SettingsSupport.js
@@ -4,6 +4,7 @@ import Snackbar from '@mui/material/Snackbar'
 import MuiAlert from '@mui/material/Alert'
 import { Typography } from '@mui/material'
 import ArrowBack from '../ArrowBack'
+import Slide from '@mui/material/Slide'
 
 import { useAuth } from '../../util/auth'
 
@@ -68,44 +69,53 @@ function SettingsSupport(props) {
         <div>
         </div>
       </Container>
-      <Container>
-        {showComponent === 'nav' && (
-          <>
-            <SupportNav auth={auth} setShowComponent={setShowComponent} />
-          </>
-        )}
-        {showComponent === 'verifyEmail' && <div>Verify email support...</div>}
-        {showComponent === 'findCourse' && <div>Find a course support...</div>}
-        {showComponent === 'createCourse' && <div>Create a course..</div>}
-        {showComponent === 'faqs' && <div>Faqs</div>}
-        <SettingsFeedbackForm
-          showComponent={showComponent}
-          setShowComponent={setShowComponent}
-          setOpenSnackbar={setOpenSnackbar}
-          setSnackbarMessage={setSnackbarMessage}
-        />
-        <SettingsBugReportForm
-          showComponent={showComponent}
-          setShowComponent={setShowComponent}
-          setOpenSnackbar={setOpenSnackbar}
-          setSnackbarMessage={setSnackbarMessage}
-        />
-        <Snackbar
-          open={openSnackbar}
-          autoHideDuration={1200}
-          onClose={() => setOpenSnackbar(false)}
-        >
-          <MuiAlert
-            elevation={6}
-            variant="filled"
+      <Slide
+      direction="left"
+      in={showComponent}
+      timeout={600}
+      mountOnEnter
+      unmountOnExit
+      >
+        <Container>
+          {showComponent === 'nav' && (
+            <>
+              <SupportNav auth={auth} setShowComponent={setShowComponent} />
+            </>
+          )}
+          {showComponent === 'verifyEmail' && <div>Verify email support...</div>}
+          {showComponent === 'findCourse' && <div>Find a course support...</div>}
+          {showComponent === 'createCourse' && <div>Create a course..</div>}
+          {showComponent === 'faqs' && <div>Faqs</div>}
+          
+          <SettingsFeedbackForm
+            showComponent={showComponent}
+            setShowComponent={setShowComponent}
+            setOpenSnackbar={setOpenSnackbar}
+            setSnackbarMessage={setSnackbarMessage}
+          />
+          <SettingsBugReportForm
+            showComponent={showComponent}
+            setShowComponent={setShowComponent}
+            setOpenSnackbar={setOpenSnackbar}
+            setSnackbarMessage={setSnackbarMessage}
+          />
+          <Snackbar
+            open={openSnackbar}
+            autoHideDuration={1200}
             onClose={() => setOpenSnackbar(false)}
-            severity={'success'}
-            sx={{ width: '100%' }}
           >
-            {snackbarMessage}
-          </MuiAlert>
-        </Snackbar>
-      </Container>
+            <MuiAlert
+              elevation={6}
+              variant="filled"
+              onClose={() => setOpenSnackbar(false)}
+              severity={'success'}
+              sx={{ width: '100%' }}
+            >
+              {snackbarMessage}
+            </MuiAlert>
+          </Snackbar>
+        </Container>
+      </Slide>
     </>
   )
 }

--- a/src/components/Settings/SettingsTermsOfService.js
+++ b/src/components/Settings/SettingsTermsOfService.js
@@ -4,121 +4,130 @@ import List from '@mui/material/List'
 import ListItem from '@mui/material/ListItem'
 import ListItemText from '@mui/material/ListItemText'
 import Typography from '@mui/material/Typography'
+import Slide from '@mui/material/Slide'
 
 function TermsOfService({ setShowComponent }) {
   return (
-    <Box
-      sx={{
-        display: 'flex',
-        flexDirection: 'column',
-      }}
+    <Slide
+    direction="left"
+    in={setShowComponent}
+    timeout={600}
+    mountOnEnter
+    unmountOnExit
     >
-      <Box sx={{ padding: '.5rem 0' }}>
-        <Typography variant="h6">Terms of Service</Typography>
-      </Box>
-      <List disablePadding>
-        <ListItem flexDirection="column">
-          <ListItemText>
-            <Typography>
-              <b>1. Acceptance of Terms</b>
-            </Typography>
-            <Typography>
-              Welcome to TakingITGlobal! TakingITGlobal provides its service to
-              you, subject to the following Terms of Service ("TOS"), which may
-              be updated by us from time to time without notice to you. You can
-              review the most current version of the TOS at any time at:
-              https://www.tigweb.org/static/disclaimer.html. In addition, when
-              using particular TakingITGlobal services, you and TakingITGlobal
-              shall be subject to any posted guidelines or rules applicable to
-              such services which may be posted from time to time. All such
-              guidelines or rules are hereby incorporated by reference into the
-              TOS.
-            </Typography>
-          </ListItemText>
-        </ListItem>
-        <ListItem>
-          <ListItemText>
-            <Typography>
-              <b>2. Description of Service</b>
-            </Typography>
-            <Typography>
-              TakingITGlobal currently provides users with access to a rich
-              collection of resources, including various communications tools,
-              databases of information, collections of expressions, forums, and
-              content through its web site(s) (the "Service"). Unless explicitly
-              stated otherwise, any new features that augment or enhance the
-              current Service, including the release of new TakingITGlobal sites
-              and features, shall be subject to the TOS.
-            </Typography>
-          </ListItemText>
-        </ListItem>
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+        }}
+      >
+        <Box sx={{ padding: '.5rem 0' }}>
+          <Typography variant="h6">Terms of Service</Typography>
+        </Box>
+        <List disablePadding>
+          <ListItem flexDirection="column">
+            <ListItemText>
+              <Typography>
+                <b>1. Acceptance of Terms</b>
+              </Typography>
+              <Typography>
+                Welcome to TakingITGlobal! TakingITGlobal provides its service to
+                you, subject to the following Terms of Service ("TOS"), which may
+                be updated by us from time to time without notice to you. You can
+                review the most current version of the TOS at any time at:
+                https://www.tigweb.org/static/disclaimer.html. In addition, when
+                using particular TakingITGlobal services, you and TakingITGlobal
+                shall be subject to any posted guidelines or rules applicable to
+                such services which may be posted from time to time. All such
+                guidelines or rules are hereby incorporated by reference into the
+                TOS.
+              </Typography>
+            </ListItemText>
+          </ListItem>
+          <ListItem>
+            <ListItemText>
+              <Typography>
+                <b>2. Description of Service</b>
+              </Typography>
+              <Typography>
+                TakingITGlobal currently provides users with access to a rich
+                collection of resources, including various communications tools,
+                databases of information, collections of expressions, forums, and
+                content through its web site(s) (the "Service"). Unless explicitly
+                stated otherwise, any new features that augment or enhance the
+                current Service, including the release of new TakingITGlobal sites
+                and features, shall be subject to the TOS.
+              </Typography>
+            </ListItemText>
+          </ListItem>
 
-        <ListItem>
-          <ListItemText>
-            <Typography>
-              <b>3. Your obligations as a member</b>
-            </Typography>
-            <Typography>
-              In consideration of your use of the Service, you agree to: (a)
-              provide true, accurate, current and complete information about
-              yourself as prompted by the Service's registration form (such
-              information being the "Registration Data") and (b) maintain and
-              promptly update the Registration Data to keep it true, accurate,
-              current and complete. If you provide any information that is
-              untrue, inaccurate, not current or incomplete, or TakingITGlobal
-              has reasonable grounds to suspect that such information is untrue,
-              inaccurate, not current or incomplete, TakingITGlobal has the
-              right to suspend or terminate your account and refuse any and all
-              current or future use of the Service (or any portion thereof).
-            </Typography>
-          </ListItemText>
-        </ListItem>
-        <ListItem>
-          <ListItemText>
-            <Typography>
-              <b>4. Member account, password, and security</b>
-            </Typography>
-            <Typography>
-              You select a username and password upon completing the Service's
-              registration process. You are responsible for maintaining the
-              confidentiality of your password, and are fully responsible for
-              all activities that occur under your password. You agree to (a)
-              immediately notify TakingITGlobal of any unauthorized use of your
-              password or account or any other breach of security, and (b)
-              ensure that you exit from your account at the end of each session.
-              TakingITGlobal cannot and will not be liable for any loss or
-              damage arising from your failure to comply with this Section.
-            </Typography>
-          </ListItemText>
-        </ListItem>
-        <ListItem>
-          <ListItemText>
-            <Typography>
-              <b>5. Member Conduct</b>
-            </Typography>
-            <Typography>
-              You understand that all information, data, text, software, music,
-              sound, photographs, graphics, video, messages or other materials
-              ("Content"), whether publicly posted or privately transmitted, are
-              the sole responsibility of the person from which such Content
-              originated. This means that you, and not TakingITGlobal, are
-              entirely responsible for all Content that you upload, post, email,
-              transmit or otherwise make available via the Service.
-              TakingITGlobal has limited control of the Content posted via the
-              Service and, as such, does not guarantee the accuracy, integrity
-              or quality of such Content. You understand that by using the
-              Service, you may be exposed to Content that is offensive, indecent
-              or objectionable. Under no circumstances will TakingITGlobal be
-              liable in any way for any Content, including, but not limited to,
-              for any errors or omissions in any Content, or for any loss or
-              damage of any kind incurred as a result of the use of any Content
-              posted, emailed, transmitted or otherwise made available via the
-              Service.
-            </Typography>
-          </ListItemText>
-        </ListItem>
-      </List>
-    </Box>
+          <ListItem>
+            <ListItemText>
+              <Typography>
+                <b>3. Your obligations as a member</b>
+              </Typography>
+              <Typography>
+                In consideration of your use of the Service, you agree to: (a)
+                provide true, accurate, current and complete information about
+                yourself as prompted by the Service's registration form (such
+                information being the "Registration Data") and (b) maintain and
+                promptly update the Registration Data to keep it true, accurate,
+                current and complete. If you provide any information that is
+                untrue, inaccurate, not current or incomplete, or TakingITGlobal
+                has reasonable grounds to suspect that such information is untrue,
+                inaccurate, not current or incomplete, TakingITGlobal has the
+                right to suspend or terminate your account and refuse any and all
+                current or future use of the Service (or any portion thereof).
+              </Typography>
+            </ListItemText>
+          </ListItem>
+          <ListItem>
+            <ListItemText>
+              <Typography>
+                <b>4. Member account, password, and security</b>
+              </Typography>
+              <Typography>
+                You select a username and password upon completing the Service's
+                registration process. You are responsible for maintaining the
+                confidentiality of your password, and are fully responsible for
+                all activities that occur under your password. You agree to (a)
+                immediately notify TakingITGlobal of any unauthorized use of your
+                password or account or any other breach of security, and (b)
+                ensure that you exit from your account at the end of each session.
+                TakingITGlobal cannot and will not be liable for any loss or
+                damage arising from your failure to comply with this Section.
+              </Typography>
+            </ListItemText>
+          </ListItem>
+          <ListItem>
+            <ListItemText>
+              <Typography>
+                <b>5. Member Conduct</b>
+              </Typography>
+              <Typography>
+                You understand that all information, data, text, software, music,
+                sound, photographs, graphics, video, messages or other materials
+                ("Content"), whether publicly posted or privately transmitted, are
+                the sole responsibility of the person from which such Content
+                originated. This means that you, and not TakingITGlobal, are
+                entirely responsible for all Content that you upload, post, email,
+                transmit or otherwise make available via the Service.
+                TakingITGlobal has limited control of the Content posted via the
+                Service and, as such, does not guarantee the accuracy, integrity
+                or quality of such Content. You understand that by using the
+                Service, you may be exposed to Content that is offensive, indecent
+                or objectionable. Under no circumstances will TakingITGlobal be
+                liable in any way for any Content, including, but not limited to,
+                for any errors or omissions in any Content, or for any loss or
+                damage of any kind incurred as a result of the use of any Content
+                posted, emailed, transmitted or otherwise made available via the
+                Service.
+              </Typography>
+            </ListItemText>
+          </ListItem>
+        </List>
+      </Box>
+    </Slide>
   )
 }
 


### PR DESCRIPTION
# Description
[TIG-552](https://app.clickup.com/t/9009201449/TIG-552)

Added a slide-in transition for all setting links:
- My Accounts
- Help and Support
- Legal and About

There are also slide-in transition for items within the individual menu links.

Note: The common questions do not currently work because the section is unfinished.

## Potential Issues
`unmountOnExit` doesn't work. The slide-in transition only slides in to the left, but there is no transition for it to 'slide out', even though `unmountOnExit` is applied to the transition. The 'Legal and About' transition works, but it runs again when you exit from a link within 'Legal and About'. I'm pretty sure it is supposed to do this, but the behaviour isn't consistent with the other setting links.

## After
![chrome-capture-2024-1-31](https://github.com/TakingITGlobal/create-to-learn/assets/132935720/34da32a7-b40c-4170-b3be-95fc3611e9ee)
