### PR TITLE
TIG 208 - Image Size at Dashboard

### DIFF
--- a/src/components/Dashboard/DashboardCreatorsMessage.js
+++ b/src/components/Dashboard/DashboardCreatorsMessage.js
@@ -121,6 +121,7 @@ const DashboardCreatorsMessage = ({ creators }) => {
                       borderColor: '#000',
                       color: '#000',
                       padding: '0.5em',
+                      textAlign: 'center',
                     }}
                     //Make this better
                     href={

--- a/src/components/Dashboard/DashboardTopCourses.js
+++ b/src/components/Dashboard/DashboardTopCourses.js
@@ -58,6 +58,7 @@ const DashboardTopCourses = ({ title, courses, icon }) => {
                 margin: '0 10px',
               }}
             >
+            {/* Gray Box Area of the Card */}
               <CardActionArea
                 sx={{
                   height: '100%',
@@ -68,8 +69,9 @@ const DashboardTopCourses = ({ title, courses, icon }) => {
                   justifyContent: 'flex-start',
                   backgroundColor: theme.palette.background.secondary,
                 }}
-                href={'/course/' + course.uid}
+                href={'/tutorial/' + course.uid}
               >
+              {/* Image of the Card */}
                 <CardMedia
                   component="img"
                   alt={`${course.seriesName}-course`}
@@ -77,12 +79,12 @@ const DashboardTopCourses = ({ title, courses, icon }) => {
                     display: 'flex',
                     alignItems: 'center',
                     width: '100%',
-                    height: '200px',
                     borderRadius: '6px',
                     objectFit: 'cover',
                   }}
                   image={course.thumbnail[0]?.downloadURL}
                 />
+                {/* Words in Card*/}
                 <CardContent
                   sx={{
                     display: 'flex',
@@ -90,11 +92,29 @@ const DashboardTopCourses = ({ title, courses, icon }) => {
                     padding: '10px 0 0 0',
                   }}
                 >
-                  <Box componant="div">
-                    <Typography component="h3" variant="bold">
+                  <Box sx={{ display:'flex', flexDirection:'column' }}>
+                    <Typography 
+                      component="h3" 
+                      variant="bold"
+                      sx = {{
+                        maxWidth: '250px',
+                        whiteSpace: 'nowrap',
+                        textOverflow: 'ellipsis',
+                        overflow: 'hidden',
+                      }}
+                    >
                       {course.seriesName}
                     </Typography>
-                    <Typography variant="body" component="p">
+                    <Typography 
+                      variant="body" 
+                      component="p"
+                      sx = {{
+                        maxWidth: '250px',
+                        whiteSpace: 'nowrap',
+                        textOverflow: 'ellipsis',
+                        overflow: 'hidden',
+                      }}
+                    >
                       {course.creator}
                     </Typography>
                     <Stack direction="row">

--- a/src/components/Dashboard/DashboardTopCourses.js
+++ b/src/components/Dashboard/DashboardTopCourses.js
@@ -14,25 +14,28 @@ import 'react-multi-carousel/lib/styles.css'
 
 import { useTranslation } from 'react-i18next'
 
-const responsive = {
-  desktop: {
-    breakpoint: { max: 3000, min: 1024 },
-    items: 3,
-    partialVisibilityGutter: 60,
-  },
-  tablet: {
-    breakpoint: { max: 1024, min: 464 },
-    items: 2,
-    partialVisibilityGutter: 50,
-  },
-  mobile: {
-    breakpoint: { max: 464, min: 0 },
-    items: 1,
-    partialVisibilityGutter: 100,
-  },
-}
 
 const DashboardTopCourses = ({ title, courses, icon }) => {
+  const coursesLength = courses.length;
+
+  const responsive = {
+    desktop: {
+      breakpoint: { max: 3000, min: 1024 },
+      items: 3,
+      partialVisibilityGutter: coursesLength < 4 ? 0 : 60, 
+    },
+    tablet: {
+      breakpoint: { max: 1024, min: 464 },
+      items: 2,
+      partialVisibilityGutter: 50,
+    },
+    mobile: {
+      breakpoint: { max: 464, min: 0 },
+      items: 1,
+      partialVisibilityGutter: 100,
+    },
+  }
+
   const theme = useTheme()
   const { t } = useTranslation()
 
@@ -56,6 +59,8 @@ const DashboardTopCourses = ({ title, courses, icon }) => {
               sx={{
                 padding: '0',
                 margin: '0 10px',
+                display: 'flex',
+                justifyContent:'flex-start',
               }}
             >
             {/* Gray Box Area of the Card */}
@@ -97,7 +102,7 @@ const DashboardTopCourses = ({ title, courses, icon }) => {
                       component="h3" 
                       variant="bold"
                       sx = {{
-                        maxWidth: '250px',
+                        maxWidth: {xs:'53vw', sm:'25vw', md:'20vw'},
                         whiteSpace: 'nowrap',
                         textOverflow: 'ellipsis',
                         overflow: 'hidden',
@@ -109,7 +114,7 @@ const DashboardTopCourses = ({ title, courses, icon }) => {
                       variant="body" 
                       component="p"
                       sx = {{
-                        maxWidth: '250px',
+                        maxWidth: {sm:'30vw', md:'20vw'},
                         whiteSpace: 'nowrap',
                         textOverflow: 'ellipsis',
                         overflow: 'hidden',
@@ -121,8 +126,17 @@ const DashboardTopCourses = ({ title, courses, icon }) => {
                       <Typography variant="subtitle1" component="p">
                         {course.difficultyLevel}
                       </Typography>
-                      <>&#183;</>
-                      <Typography variant="subtitle1" component="p">
+                      <Box padding={'0 3px'}>&#183;</Box>
+                      <Typography 
+                        variant="subtitle1" 
+                        component="p"
+                        sx = {{
+                          maxWidth: {sm:'30vw', md:'20vw'},
+                          whiteSpace: 'nowrap',
+                          textOverflow: 'ellipsis',
+                          overflow: 'hidden',
+                      }}  
+                      >
                         {course.videos.length} {t('videos')}
                       </Typography>
                     </Stack>

--- a/src/util/theme.js
+++ b/src/util/theme.js
@@ -53,8 +53,8 @@ export const c2learn = (mode) => ({
   breakpoints: {
     values: {
       xs: 0,
-      sm: 600,
-      md: 960,
+      sm: 464,
+      md: 1024,
       lg: 1200,
       xl: 1920,
     },


### PR DESCRIPTION
# Description
[TIG 208](https://app.clickup.com/t/9009201449/TIG-208)

Video thumbnails do not cut off anymore when the screen is being resized. I also made the dashboard featured videos more responsive when the screen size changes.

## Before
![image](https://github.com/TakingITGlobal/create-to-learn/assets/132935720/4fefdab9-9519-488f-9fdb-52e789d20bd0)

## After
![image](https://github.com/TakingITGlobal/create-to-learn/assets/132935720/c0975cf3-400c-4e4b-8339-ffa429fe990a)
![image](https://github.com/TakingITGlobal/create-to-learn/assets/132935720/eeea9049-1475-4505-8d36-3168d76f1d50)
