### PR TITLE
TIG-212 - Bug my courses scroll

### DIFF
--- a/src/components/CreatorSection.js
+++ b/src/components/CreatorSection.js
@@ -21,7 +21,7 @@ function CreatorSection({ coursesByCreator, creator }) {
     <Helmet>
       <title>{creator.name} | Creators | Create to Learn</title>
     </Helmet>
-      <Container>
+      <Container sx = {{ paddingBottom:'90px'}}>
         <Box sx={{display: {md: 'flex'}, gap: {md: '20px'}, paddingBottom: {md: '40px'}}}>
           <Box
             alt={creator.name}

--- a/src/components/MyCourses/MyCoursesDownloads.js
+++ b/src/components/MyCourses/MyCoursesDownloads.js
@@ -117,6 +117,7 @@ function MyCoursesDownloads() {
       buttonText={emptyStateButtonText}
       href={'/browse'}
     />
+
   )
 }
 

--- a/src/components/MyCourses/MyCoursesEmptyState.tsx
+++ b/src/components/MyCourses/MyCoursesEmptyState.tsx
@@ -49,6 +49,7 @@ const MyCoursesEmptyState = ({ title, subtitle, buttonText, href }: Props) => {
           flexDirection: 'row',
           alignItems: 'center',
           justifyContent: 'center',
+          paddingBottom: '90px'
         }}
       >
         <Button variant="contained" size="large" component={Link} to={href}>


### PR DESCRIPTION
# Description
[TIG-212](https://app.clickup.com/t/9009201449/TIG-212)

The bottom navigation was hiding some of the buttons in some of the areas (depending on the screen size). 

Fixed now by adding some padding to the section body.

## Before
![image](https://github.com/TakingITGlobal/create-to-learn/assets/132935720/b49ac9b0-b3e6-4ee6-8934-1a8d21a8b612)
## After
![image](https://github.com/TakingITGlobal/create-to-learn/assets/132935720/5a39fac7-914e-471c-b8fd-8661651e185a)
