### PR TITLE
[TIG-618] - Padding Bottom for Mobile

### DIFF
--- a/src/components/CreatorSection.js
+++ b/src/components/CreatorSection.js
@@ -17,7 +17,11 @@ function CreatorSection({ coursesByCreator, creator }) {
 
   return (
     <Section>
-      <Container>
+      <Container 
+        sx = {{
+          paddingBottom: '100px'
+        }}
+      >
         <Box
           sx={{
             display: { md: 'flex' },

--- a/src/components/MyCourses/MyCoursesSection.js
+++ b/src/components/MyCourses/MyCoursesSection.js
@@ -51,7 +51,11 @@ function MyCoursesSection(props) {
       bgImage={props.bgImage}
       bgImageOpacity={props.bgImageOpacity}
     >
-      <Container>
+      <Container
+      sx = {{
+        paddingBottom: '100px'
+      }}
+      >
         <PageHeading headingText={t('my-courses.my-courses')} />
         <Box>
           <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>


### PR DESCRIPTION
# Description
[TIG-618](https://app.clickup.com/t/9009201449/TIG-618)

Visual Update - I added padding bottom so some elements don't get covered up by the mobile bottom navigation.

Steps to Check:
- [ ] Nowhere in the mobile format should have the bottom navigation cutting off any elements

## Before
![image](https://github.com/TakingITGlobal/create-to-learn/assets/132935720/2654b11d-fe84-442b-973e-0713aa01f160)

## After
In MyCourses:
![image](https://github.com/TakingITGlobal/create-to-learn/assets/132935720/c7c84d3f-af13-4f75-9e40-9ee466496986)

In Creator Section:
![image](https://github.com/TakingITGlobal/create-to-learn/assets/132935720/d11648e7-6806-4ca6-be9f-711c517b3dde)

